### PR TITLE
Use addLabels API instead of update for adding PR labels

### DIFF
--- a/src/github-ops.ts
+++ b/src/github-ops.ts
@@ -98,12 +98,14 @@ export class GithubOps {
       throw new Error(`Falsy issue number`)
     }
 
-    await this.kit.issues.update({
-      owner: r.owner,
-      repo: r.name,
-      issue_number: issueNumber,
-      labels: this.prLabels,
-    })
+    if (this.prLabels.length > 0) {
+      await this.kit.issues.addLabels({
+        owner: r.owner,
+        repo: r.name,
+        issue_number: issueNumber,
+        labels: this.prLabels,
+      })
+    }
 
     return issueNumber
   }


### PR DESCRIPTION
Motivation: 

```
[@octokit/request] "PATCH https://api.github.com/repos/moojo-tech/antelope/issues/7682" is deprecated. It is scheduled to be removed on Fri, 10 Mar 2028 00:00:00 GMT. See https://docs.github.com/en/rest/about-the-rest-api/api-versions
```


## Implementation Details
The `addLabels()` method is more semantically appropriate for this use case since we're specifically adding labels rather than performing a general issue update. The added length check prevents making API calls when there are no labels to add, improving efficiency.

https://claude.ai/code/session_01M2ZQJemqV5MDgj9pFeV1LM